### PR TITLE
EZP-28161: Update php-cs-fixer configuration to align with v2.7.1

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,27 +1,36 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
-    ->setUsingLinter(false)
-    ->setUsingCache(true)
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    ->fixers([
-        'concat_with_spaces',
-        '-concat_without_spaces',
-        '-empty_return',
-        '-phpdoc_params',
-        '-phpdoc_separation',
-        '-phpdoc_to_comment',
-        '-spaces_cast',
-        '-blankline_after_open_tag',
-        '-single_blank_line_before_namespace',
-    ])
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
-            ->in(__DIR__)
-            ->exclude([
-                'vendor',
-                'Resources'
-            ])
-            ->files()->name('*.php')
+// PHP-CS-Fixer 2.x syntax
+return PhpCsFixer\Config::create()
+    ->setRules(
+        [
+            '@Symfony' => true,
+            '@Symfony:risky' => true,
+            'concat_space' => ['spacing' => 'one'],
+            'array_syntax' => false,
+            'simplified_null_return' => false,
+            'phpdoc_align' => false,
+            'phpdoc_separation' => false,
+            'phpdoc_to_comment' => false,
+            'cast_spaces' => false,
+            'blank_line_after_opening_tag' => false,
+            'single_blank_line_before_namespace' => false,
+            'phpdoc_annotation_without_dot' => false,
+            'phpdoc_no_alias_tag' => false,
+            'space_after_semicolon' => false,
+            'yoda_style' => false,
+            'no_break_comment' => false,
+        ]
     )
-;
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->exclude(
+                [
+                    'vendor',
+                    'Resources',
+                ]
+            )
+            ->files()->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+
+php:
+    - 7.1
+
+# test only master and stable branches (+ Pull requests)
+branches:
+    only:
+        - master
+        - /^\d.\d+$/
+
+install:
+    # Disable XDebug for better performance
+    - phpenv config-rm xdebug.ini
+    # Avoid memory issues on composer install
+    - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    # Get latest composer build
+    - travis_retry composer selfupdate
+    # Install packages
+    - travis_retry composer install --prefer-dist --no-interaction
+
+script:
+    - vendor/bin/php-cs-fixer fix -v --dry-run --diff --show-progress=estimating
+
+notifications:
+    email: false

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "symfony/symfony": "~2.6"
+    "symfony/symfony": "~2.6 || ^3.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
   "require": {
     "symfony/symfony": "~2.6 || ^3.3"
   },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "~2.7.1"
+  },
   "autoload": {
     "psr-4": {
       "EzSystems\\ShareButtonsBundle\\": ""

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
       "EzSystems\\ShareButtonsBundle\\": ""
     }
   },
+  "scripts": {
+    "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "1.0.x-dev"


### PR DESCRIPTION
# Fixes [EZP-28161](https://jira.ez.no/browse/EZP-28161)

This PR updates `.php_cs` config to be compatible with `v2.7.1`.

To simplify fixing code it also adds dev dependency on `php-cs-fixer` and introduces composer command:
```
composer fix-cs
```
which runs fixer on all files.

**TODO**:
- [x] Update php-cs-fixer config (`.php_cs`)
- [x] Allow Symfony `^3.3`
- [x] Add `php-cs-fixer` dev dependency to composer pointing to `~2.7.1`
- [x] Add composer command `fix-cs`